### PR TITLE
send configuration settings in testConnection

### DIFF
--- a/Examples/ReadLoop/ReadLoop.ino
+++ b/Examples/ReadLoop/ReadLoop.ino
@@ -14,15 +14,17 @@ void setup() {
   while (!Serial) {}  // wait for Serial comms to become ready
   Serial.println("Starting up");
   Serial.println("Testing device connection...");
-    Serial.println(myADC.testConnection() ? "MCP342X connection successful" : "MCP342X connection failed");
-    
+  
   myADC.configure( MCP342X_MODE_CONTINUOUS |
                    MCP342X_CHANNEL_1 |
                    MCP342X_SIZE_16BIT |
                    MCP342X_GAIN_1X
                  );
-
-  Serial.println(myADC.getConfigRegShdw(), HEX);
+  
+  Serial.print("ConfigRegShdw: 0b"); 
+  Serial.println(myADC.getConfigRegShdw(), BIN); // verify the settings
+  
+  Serial.println(myADC.testConnection() ? "MCP342X connection successful" : "MCP342X connection failed");
   
 }  // End of setup()
 

--- a/MCP342X.cpp
+++ b/MCP342X.cpp
@@ -70,6 +70,7 @@ MCP342X::MCP342X(uint8_t address) {
  */
 bool MCP342X::testConnection() {
     Wire.beginTransmission(devAddr);
+    Wire.write(configRegShdw | MCP342X_RDY);
     return (Wire.endTransmission() == 0);
 }
 


### PR DESCRIPTION
Hello: This is the first time I've used github to contribute to community. 

I used this library on MCP3425. The non-blocking routines work, but weird stuff happened when I tried using them without sending the configuration bit first in setup(). That isn't abundantly clear during its use. 

So, in preparation of me submitting a ReadLoop_NonBlocking.ino example code, this small change is needed. 